### PR TITLE
Inner content Div added to allow content divs with relative (eg 90%) sizes to be handled correctly;

### DIFF
--- a/Default.aspx
+++ b/Default.aspx
@@ -27,6 +27,8 @@
         <input type="button" id="btnAddA" value="Add Tab A" />
         &nbsp
         <input type="button" id="btnAddB" value="Add Tab B" />
+        &nbsp
+        <input type="button" id="btnAddC" value="Add Tab C" />
         <br />
 
 
@@ -37,9 +39,16 @@
         <div id="divPlaceHolderA"></div>
         <br />
         <br />
-        And the DIV below is an example where the height is not fixed
+        The DIV below is an example where the placeholder height is not fixed
         <br />
         <div id="divPlaceHolderB"></div>
+        <br />
+        <br />
+        The DIV below is an example where the content of the tab is sized by relative percentage, rather than being fixed pixel size.
+        <br />
+        <div id="divPlaceHolderC"></div>
+        <br />
+        <br />
 
 
     </div>

--- a/README.MD
+++ b/README.MD
@@ -12,7 +12,7 @@ Each tab control can have it's own styles set independently.
 
 If you have a web page that users interact with to create results or add data to, the resultant data needs to be displayed.
 The resultant data can be difficult to display if it varies in size or type with each interaction.
-This control was written because I had to display an indefinite number of user orders (tabular information), and allow the orders to be held open for comparison.
+This control was written because I had to display an indefinite number of user query results (tabular information), and allow the results to be held open for comparison.
 The user has the option to close tabs with an 'x' button on the tab.
 
 The control is attached to a placeholder element in HTML, and no other HTML is required.
@@ -33,30 +33,38 @@ In your main JavaScript code (see Default.js in this project) you define a JS ob
     styleDefn["tab"] = "dynatabTabTest"; 
     styleDefn["content"] = "dynatabContentTest";
     styleDefn["container"] = "dynatabContainerTest"; 
-    styleDefn["wrapper"] = "dynatabWrapperTest"; 
 
 Then call the Build() function once in the lifetime of the page, for each control you wish to construct, with a name for the control, the style object, and the HTML ID of the placeholder element that the control will be appended to.
 
     nz.dynatab.Build("TabSetA", styleDefn, "IDofPlaceHolderA");
 
 The control can now create tabs.
-A tab is added by calling AddTab() with the control name, the text to use for the tab, the HTML element to display on the tab, and a bool true/false flag to stipulate whether the 'Close' button should be added for this tab.
+A tab is added by calling AddTab() with the arguments being... 
 
-    nz.dynatab.AddTab("TabSetA", "Tab 1", contentA1, true);
+ - the control name
+ - the text to use for the tab
+ - the HTML element to display on the tab
+ - a bool flag to stipulate whether the tab content Height is relative (true) or fixed (false)
+ - a bool flag to stipulate whether the tab content Width is relative (true) or fixed (false) 
+ - an optional bool true/false flag to stipulate whether the 'Close' button should be added for this tab, which defaults to false.
+
+<!-- comment: Work around to have a code block follow a ul list --> 
+
+        nz.dynatab.AddTab("TabSetA", "Tab 1", contentA1, false, false, true);
 
 
 ## Example Project ##
 
-This project contains a very simple harness that sets up two tab areas.
-The first control has example content, the second has no starting content.
+This project contains a very simple harness that sets up three tab areas.
+The first control has example content.  The second has no starting content, and variable height.  The third also has no starting content, but has fixed height. 
 There are buttons to add content to either tab area, and that content is randomly generated.
 
 
 
 ## Implementation ##
 
-Implemented using Javascript only.
-Note: There may be functions in FCUtils.js that use JQuery, I need to investigate further.
+Implemented using Javascript only.  JQuery is used in the Default.js harness code only, there is no JQuery requirement for DynaTab.js or FCUtils.js.
+
 
 
 ## Licensing ##

--- a/css/Default.css
+++ b/css/Default.css
@@ -19,6 +19,15 @@
     padding:7px; /* Small inset, should match margin between tabs */
 }
 
+#divPlaceHolderC
+{
+    width:600px; 
+    height:200px; 
+    background-color:#EEEEEE; /* A colour, so that the div can be seen */
+    padding:7px; /* Small inset, should match margin between tabs */
+}
+
+
 
 
 /**************************/

--- a/js/Default.js
+++ b/js/Default.js
@@ -65,40 +65,37 @@ nz.test.init = function () {
 
 
 
-    // Tests:
+    // Create tab sets to display content divs:
 
-    // Try attaching a dynatab to a container that does not exist.
     var phA = document.getElementById("divPlaceHolderA");
     nz.dynatab.Build("TabSetA", styleDefn, phA.id);
 
     nz.dynatab.Build("TabSetB", styleDefn, "divPlaceHolderB");
 
-    // Make something to show in the tab and show
+    nz.dynatab.Build("TabSetC", styleDefn, "divPlaceHolderC");
+
+
+    // Make something to show in the tab A set and show
     var contentA1 = document.createElement("div");
     contentA1.id = "divContentA1";
     contentA1.innerHTML = "DIV ContentA1";
-    nz.dynatab.AddTab("TabSetA", "Tab 1", contentA1, true);
+    nz.dynatab.AddTab("TabSetA", "Tab 1", contentA1, false, false, true);
 
-    // Make something to show in the tab show
     var contentA2 = document.createElement("div");
     contentA2.id = "divContentA2";
     contentA2.innerHTML = "DIV ContentA2";
-    nz.dynatab.AddTab("TabSetA", "Tab Number 2", contentA2, true);
+    nz.dynatab.AddTab("TabSetA", "Tab Number 2", contentA2, false, false, true);
 
-    // Make something to show in the tab show
     var contentA3 = document.createElement("div");
     contentA3.id = "divContentA3";
     contentA3.innerHTML = "DIV ContentA3";
-    nz.dynatab.AddTab("TabSetA", "Tab The Third of Many", contentA3, true);
+    nz.dynatab.AddTab("TabSetA", "Tab The Third of Many", contentA3, false, false, true);
 
-    // Make something to show in the tab show
     var contentA4 = document.createElement("div");
     contentA4.id = "divContentA4";
     contentA4.innerHTML = "DIV ContentA4";
-    nz.dynatab.AddTab("TabSetA", "Tab 4th", contentA4, true);
+    nz.dynatab.AddTab("TabSetA", "Tab 4th", contentA4, false, false, true);
 
-
-    // Try attaching a dynatab to a container that already has a dynatab.
 
     console.log(prefix + "Exiting");
 }
@@ -117,7 +114,12 @@ nz.test.getRandomString = function (nStringLength) {
 }
 
 
-nz.test.createRandomContent = function () {
+nz.test.createRandomContent = function (bFixedWidth) {
+
+    bFixedWidth = (typeof bFixedWidth === 'undefined') ? true : bFixedWidth; // Default syntax; Default to true
+
+
+
     var divRandom = document.createElement("div");
     divRandom.id = nz.test.config.sDivRandomPrefix + (++nz.test.config.nDivSeqNum).toString();
     divRandom.innerHTML = nz.test.getRandomString(32);
@@ -125,10 +127,30 @@ nz.test.createRandomContent = function () {
     divRandom.style.backgroundColor = nz.test.createRandomRGBColour(0, 64, 0, 64, 0, 64);
     divRandom.style.color = nz.test.createRandomRGBColour(191, 255, 191, 255, 191, 255);
 
-    var sHeight = (fc.utils.getRandomInt(50,800)).toString() + "px";
-    divRandom.style.height = sHeight;
+    var sHeight = "";
+    var sWidth = "";
 
-    var sWidth = (fc.utils.getRandomInt(100, 1000)).toString() + "px";
+    if (bFixedWidth) {
+        sHeight = (fc.utils.getRandomInt(50, 800)).toString() + "px";
+        sWidth = (fc.utils.getRandomInt(100, 1000)).toString() + "px";
+    }
+    else {
+        nz.test.config.once = nz.test.config.once || false;
+        var bCoinToss = fc.utils.getRandomInt(0, 1) == 0 ? true : false; // 50-50 chance of true or false
+        if (bCoinToss && nz.test.config.once) {
+            // Use random relative size
+            sHeight = (fc.utils.getRandomInt(1, 100)).toString() + "%";
+            sWidth = (fc.utils.getRandomInt(1, 100)).toString() + "%";
+        }
+        else {
+            // Use full size
+            sHeight = "100%";
+            sWidth = "100%";
+            nz.test.config.once = true;
+        }
+    }
+
+    divRandom.style.height = sHeight;
     divRandom.style.width = sWidth;
 
     document.documentElement.appendChild(divRandom);
@@ -161,7 +183,7 @@ nz.test.btnAddA_onClick = function (id, event) {
 
     var content = nz.test.createRandomContent();
     var sTabText = "Tab " + nz.test.config.nDivSeqNum.toString();
-    nz.dynatab.AddTab("TabSetA", sTabText, content, true);
+    nz.dynatab.AddTab("TabSetA", sTabText, content, false, false, true);
 }
 
 nz.test.btnAddB_onClick = function (id, event) {
@@ -170,7 +192,17 @@ nz.test.btnAddB_onClick = function (id, event) {
 
     var content = nz.test.createRandomContent();
     var sTabText = "Tab " + nz.test.config.nDivSeqNum.toString();
-    nz.dynatab.AddTab("TabSetB", sTabText, content, true);
+    nz.dynatab.AddTab("TabSetB", sTabText, content, false, false, true);
+}
+
+
+nz.test.btnAddC_onClick = function (id, event) {
+    var prefix = "nz.test.btnAddC_onClick() - ";
+    nz.test.log(prefix + "Clicked: " + id);
+
+    var content = nz.test.createRandomContent(false); // Random, relative sized content divs
+    var sTabText = "Tab " + nz.test.config.nDivSeqNum.toString();
+    nz.dynatab.AddTab("TabSetC", sTabText, content, true, true, true);
 }
 
 
@@ -181,5 +213,8 @@ nz.test.hookupHandlers = function () {
 
     var btnAddB = document.getElementById("btnAddB");
     fc.utils.addEvent(btnAddB, "click", nz.test.btnAddB_onClick);
+
+    var btnAddC = document.getElementById("btnAddC");
+    fc.utils.addEvent(btnAddC, "click", nz.test.btnAddC_onClick);
 }
 

--- a/js/FCUtils.js
+++ b/js/FCUtils.js
@@ -4,7 +4,6 @@
 
 
 // To include files for VS to understand and query them, use this syntax..
-// ///<reference path="../FCUtils.js" />
 
 // Define the console if not already defined
 if (!window.console) console = { log: function () { } };
@@ -213,7 +212,9 @@ fc.utils.insertAtIndex = function (sTarget, sInsert, index) {
     return sTarget.substring(0, index) + sInsert + sTarget.substring(index);
 }
 
-
+fc.utils.endsWith = function (sTarget, sSuffix) {
+    return sTarget.indexOf(sSuffix, sTarget.length - sSuffix.length) !== -1;
+};
 
 ///////////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
CHANGED: DynaTab.js
- AddTab() changed to accept two new arguments to indicate tab content sizing styles in Height and Width,
  and to record data for later resizing routines.
- createDivContent() now adds an inner Div before appending content.
- setTabSelected() has had the order in which it calls the size reset functions reversed, so that Width is handled first,
  which solves a small sizing bug.
- resetDivContentHeight() now accommodates the inner div and sets the size.
- resetDivContentWidth() now checks whether content is relative sizing and adjusts calculations accordingly.
- Config variables updated for ContentInner div.

CHANGED: FCUtils.js
- endsWith() added.

CHANGED: Default.aspx
- Added third test placeholder div to test tab content with relative sizes ie 100% etc.
- Added btnAddC to allow new tabs to be created on the fly.
- Visual text updated.

CHANGED: Readme.md
- Notes updated.

CHANGED: Default.css
- Style added for divPlaceHolderC.

CHANGED: Default.js
- Calls to AddTab() updated to include additional variables.
- New third tab created.
- createRandomContent() updated to include the possibility of creating relative width content.
- hookupHandlers() updated for btnAddC
