### PR TITLE
Clear function implemented to remove all existing tabs;

### DIFF
--- a/Default.aspx
+++ b/Default.aspx
@@ -25,6 +25,7 @@
         <%-- Test Controls --%>
         <br />
         <input type="button" id="btnAddA" value="Add Tab A" />
+        <input type="button" id="btnClearA" value="Clear A" />
         &nbsp
         <input type="button" id="btnAddB" value="Add Tab B" />
         &nbsp

--- a/README.MD
+++ b/README.MD
@@ -53,6 +53,10 @@ A tab is added by calling AddTab() with the arguments being...
         nz.dynatab.AddTab("TabSetA", "Tab 1", contentA1, false, false, true);
 
 
+To remove all tabs, a Clear() function has been implemented, which requires the control name as an argument.
+
+
+
 ## Example Project ##
 
 This project contains a very simple harness that sets up three tab areas.

--- a/js/Default.js
+++ b/js/Default.js
@@ -186,6 +186,14 @@ nz.test.btnAddA_onClick = function (id, event) {
     nz.dynatab.AddTab("TabSetA", sTabText, content, false, false, true);
 }
 
+nz.test.btnClearA_onClick = function (id, event) {
+    var prefix = "nz.test.btnClearA_onClick() - ";
+    nz.test.log(prefix + "Clicked: " + id);
+
+    nz.dynatab.Clear("TabSetA");
+}
+
+
 nz.test.btnAddB_onClick = function (id, event) {
     var prefix = "nz.test.btnAddB_onClick() - ";
     nz.test.log(prefix + "Clicked: " + id);
@@ -216,5 +224,9 @@ nz.test.hookupHandlers = function () {
 
     var btnAddC = document.getElementById("btnAddC");
     fc.utils.addEvent(btnAddC, "click", nz.test.btnAddC_onClick);
+
+    var btnClearA = document.getElementById("btnClearA");
+    fc.utils.addEvent(btnClearA, "click", nz.test.btnClearA_onClick);
+
 }
 

--- a/js/DynaTab.js
+++ b/js/DynaTab.js
@@ -166,6 +166,60 @@ nz.dynatab.AddTab = function (sTabAreaId, sTabText, tabContent, bContentHeightIs
     return true;
 }
 
+
+// Remove all tabs
+nz.dynatab.Clear = function (sTabAreaId) {
+    var prefix = "nz.dynatab.Clear() - ";
+    nz.dynatab.log(prefix + "Entering");
+
+    // Get existing indices, call removeTab on each index value.
+
+    var indices = nz.dynatab.getIndices(sTabAreaId);
+    var j = 0;
+    for (; j < indices.length; ++j) {
+        nz.dynatab.removeTab(sTabAreaId, indices[j]);
+    }
+
+    nz.dynatab.log(prefix + "Exiting");
+}
+
+
+nz.dynatab.getIndices = function (sTabAreaId) {
+    var prefix = "nz.dynatab.getIndices() - ";
+    nz.dynatab.log(prefix + "Entering");
+
+    // Iterate the tabs and get their index values.
+    var indices = [];
+
+    var sWrapperId = nz.dynatab[sTabAreaId]["sWrapperId"];
+    var wrapper = document.getElementById(sWrapperId);
+    if (wrapper == null) {
+        nz.dynatab.error(prefix + "Could not access DynaTab wrapper; Cannot clear this tab set.");
+        return indices;
+    }
+
+    // Wrapper is not null.
+    // Iterate the child nodes, find nodes that have attribute "data-index", 
+    // record that index.
+
+    var countNodes = wrapper.childNodes.length;
+    var i = 0;
+    for (; i < countNodes; ++i) {
+        var currentNode = wrapper.childNodes[i];
+        var currentType = currentNode.getAttribute("data-divtype");
+        var currentIndex = currentNode.getAttribute("data-index");
+        if (currentType == nz.dynatab.config.sDivTypeTab) {
+            // This node is a div Tab node, so note it's index value
+            indices.push(currentIndex);
+        }
+    }
+
+    var sIndices = indices.join(", ");
+    nz.dynatab.log(prefix + "Exiting; Returning array: [" + sIndices + "]");
+    return indices;
+}
+
+
 nz.dynatab.removeTab = function (sTabAreaId, index) {
     var prefix = "nz.dynatab.removeTab() - ";
     nz.dynatab.log(prefix + "Entering");


### PR DESCRIPTION
CHANGED: Dynatab.js
- Clear() added to call remove tab on all extant indices.
- getIndices() added to walk tab wrapper and return all existing indices.

CHANGED: Default.aspx
- Clear button added for Group A.

CHANGED: Default.js
- btnClearA_onClick() handler added to test new Clear() function.
- hookupHandlers() updated to attach handler to button.

CHANGED: Readme.MD
- Text updated to include note on Clear() function.
