### PR TITLE
Dynatab can now remove a tab using the text on the tab;

### DIFF
--- a/Default.aspx
+++ b/Default.aspx
@@ -26,9 +26,11 @@
         <br />
         <input type="button" id="btnAddA" value="Add Tab A" />
         <input type="button" id="btnClearA" value="Clear A" />
-        &nbsp
+        <br />
         <input type="button" id="btnAddB" value="Add Tab B" />
-        &nbsp
+        <input type="button" id="btnRemoveB" value="Remove Tab B" />
+        <input type="text" id="textboxRemoveB" />
+        <br />
         <input type="button" id="btnAddC" value="Add Tab C" />
         <br />
 

--- a/README.MD
+++ b/README.MD
@@ -55,6 +55,9 @@ A tab is added by calling AddTab() with the arguments being...
 
 To remove all tabs, a nz.dynatab.Clear() function has been implemented, which requires the control name as an argument.
 
+To remove a tab by it's tab text (display name), a nz.dynatab.RemoveTabByTabText() function has been implemented.  
+This requires a control name, and the tab text to match on.  Text matching is case insensitive, implemented using toUpperCase() in string comparison.
+
 To detect which tab is currently selected, a callback function can be attached to a tab set.
 Once the tab area has been prepared by the Build() function, you can call nz.dynatab.SetCallback_onChange().  
 The first argument for this function is the tab area ID, and the second argument is the function that you want called when the tab selection changes, eg.

--- a/js/Default.js
+++ b/js/Default.js
@@ -183,6 +183,9 @@ nz.test.showSelectedTabSetC = function (sTabAreaId, index, sTabText) {
     lblTabSetCSelected.html(sMsg);
 }
 
+
+
+
 ///////////////////////////////////////////////////////////////////////////////
 // HANDLERS
 //
@@ -213,6 +216,17 @@ nz.test.btnAddB_onClick = function (event) {
     nz.dynatab.AddTab("TabSetB", sTabText, content, false, false, true);
 }
 
+nz.test.btnRemoveB_onClick = function (event) {
+    var prefix = "nz.test.btnRemoveB_onClick() - ";
+    nz.test.log(prefix + "Clicked: " + event.target.id);
+
+    var textboxRemoveB = $("input[id*=textboxRemoveB]");
+    var sTabText = textboxRemoveB.val();
+    nz.dynatab.RemoveTabByTabText("TabSetB", sTabText);
+}
+
+
+
 
 nz.test.btnAddC_onClick = function (event) {
     var prefix = "nz.test.btnAddC_onClick() - ";
@@ -231,6 +245,9 @@ nz.test.hookupHandlers = function () {
 
     var btnAddB = document.getElementById("btnAddB");
     fc.utils.addEvent(btnAddB, "click", nz.test.btnAddB_onClick);
+
+    var btnRemoveB = document.getElementById("btnRemoveB");
+    fc.utils.addEvent(btnRemoveB, "click", nz.test.btnRemoveB_onClick);
 
     var btnAddC = document.getElementById("btnAddC");
     fc.utils.addEvent(btnAddC, "click", nz.test.btnAddC_onClick);

--- a/js/DynaTab.js
+++ b/js/DynaTab.js
@@ -256,6 +256,56 @@ nz.dynatab.getIndices = function (sTabAreaId) {
 }
 
 
+nz.dynatab.RemoveTabByTabText = function (sTabAreaId, sTabText) {
+    var prefix = "nz.dynatab.RemoveTabByTabText() - ";
+    nz.dynatab.log(prefix + "Entering");
+
+    if (fc.utils.isInvalidVar(sTabText)) {
+        nz.dynatab.warn(prefix + "sTabText argument was invalid")
+        return;
+    }
+
+    if (!fc.utils.isString(sTabText)) {
+        nz.dynatab.warn(prefix + "sTabText argument was not a string")
+        return;
+    }
+
+    if (fc.utils.isEmptyStringOrWhiteSpace(sTabText)) {
+        nz.dynatab.warn(prefix + "sTabText argument was empty")
+        return;
+    }
+
+    // Get the index of a tab with this text, and call removeTab with it.
+
+    var sWrapperId = nz.dynatab[sTabAreaId]["sWrapperId"];
+    var wrapper = document.getElementById(sWrapperId);
+    var index = -1;
+
+    var nodes = wrapper.childNodes;
+    for (var i = 0; i < nodes.length; ++i) {
+
+        var currentNode = nodes[i];
+        var currentType = currentNode.getAttribute("data-divtype");
+        var currentIndex = currentNode.getAttribute("data-index");
+        var currentTabText = currentNode.getAttribute("data-text");
+
+        if (currentType == nz.dynatab.config.sDivTypeTab) {
+            if (currentTabText.toUpperCase() == sTabText.toUpperCase()) {
+                index = currentIndex;
+                break;
+            }
+        }
+    }
+
+    if (index == -1) {
+        nz.dynatab.log(prefix + "No tab found with text [" + sTabText + "]");
+    }
+    else {
+        nz.dynatab.removeTab(sTabAreaId, index);
+        nz.dynatab.log(prefix + "Attempted remove of tab at index [" + index + "] with text [" + sTabText + "]");
+    }
+}
+
 nz.dynatab.removeTab = function (sTabAreaId, index) {
     var prefix = "nz.dynatab.removeTab() - ";
     nz.dynatab.log(prefix + "Entering");

--- a/js/FCUtils.js
+++ b/js/FCUtils.js
@@ -77,6 +77,10 @@ fc.utils.isLetterOrDigit = function (c) {
 // TEXT
 //
 
+fc.utils.isString = function (obj) {
+    return (typeof obj == "string" || obj instanceof String);
+}
+
 fc.utils.isEmptyString = function(obj) {
 
     // If the passed object is not defined, or the object is an empty string


### PR DESCRIPTION
CHANGED: DynaTab.js
- RemoveTabByTabText() added, gets index of tab and wraps removeTab()

CHANGED: Default.js
- btnRemoveB_onClick() Handler added to wrap call to RemoveTabByTabText()
- hookupHandlers() updated to hook button to handler.

CHANGED: Default.aspx
- Button and textbox added to allow testing of ability to remove tab by TabText.

CHANGED: ReadMe.md
- Notes updated

CHANGED: FCUtils.js
- isString() added, as per other versions of this file.
